### PR TITLE
Dockerfile: add consumer.properties.template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ADD Makefile .
 RUN make download_jars
 
 # build
+ADD consumer.properties.template .
 ADD ./build/consumer ./build/consumer
 
 CMD ["make", "run_kinesis_consumer"]

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ KINESIS_APPLICATION_NAME ?= kinesis-to-firehose-local
 
 consumer_properties:
 	cp consumer.properties.template consumer.properties
-	sed -i '.bak' 's/<STREAM_NAME>/$(KINESIS_STREAM_NAME)/' consumer.properties
-	sed -i '.bak' 's/<REGION_NAME>/$(KINESIS_AWS_REGION)/' consumer.properties
-	sed -i '.bak' 's/<APPLICATION_NAME>/$(KINESIS_APPLICATION_NAME)/' consumer.properties
+	sed -i 's/<STREAM_NAME>/$(KINESIS_STREAM_NAME)/' consumer.properties
+	sed -i 's/<REGION_NAME>/$(KINESIS_AWS_REGION)/' consumer.properties
+	sed -i 's/<APPLICATION_NAME>/$(KINESIS_APPLICATION_NAME)/' consumer.properties
 
 run_kinesis_consumer: consumer_properties
 	command -v java >/dev/null 2>&1 || { echo >&2 "Java not installed. Install java!"; exit 1; }


### PR DESCRIPTION
This file needs to be present, so that `run_kinesis_consumer` can copy/rewrite it based on runtime environment.