### PR TITLE
Improves batching and adds rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ Consumes records from Kinesis and writes to Firehose.
 
 ## Running the Consumer
 
-To build and run the consumer, set required env vars for your Kinesis input stream, Firehose output stream, and logfile. Then run `make run`.
+To build and run the consumer, set required env vars. Then run, `make run`.
+
+Env vars include:
+- Kinesis input stream
+- Firehose output stream
+- logfile
+- rate limit (allows throttling the # of records-per-second to read from each Kinesis shard)
 
 ``` bash
 KINESIS_AWS_REGION=us-west-1 \
@@ -12,6 +18,7 @@ KINESIS_STREAM_NAME=kinesis-test \
 FIREHOSE_AWS_REGION=us-west-2 \
 FIREHOSE_STREAM_NAME=firehose-test \
 LOG_FILE=/tmp/kcl_stderr \
+RATE_LIMIT=100 \
 make run
 ```
 

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -80,7 +80,7 @@ func (rp *RecordProcessor) shouldUpdateSequence(sequenceNumber *big.Int, subSequ
 func (rp *RecordProcessor) ProcessRecords(records []kcl.Record, checkpointer kcl.Checkpointer) error {
 	for _, record := range records {
 		// Wait until rate limiter permits one record to be processed
-		err := rp.rateLimiter.Wait(context.Background())
+		rp.rateLimiter.Wait(context.Background())
 
 		// Base64 decode the record
 		data, err := base64.StdEncoding.DecodeString(record.Data)

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -175,7 +175,7 @@ func main() {
 
 	kclProcess := kcl.New(os.Stdin, os.Stdout, os.Stderr, &RecordProcessor{
 		firehoseWriter: writer,
-		rateLimiter:    rate.NewLimiter(300, 500), // 300/s is normal limit, 500/s is burst limit
+		rateLimiter:    rate.NewLimiter(500, 600), // 300/s is normal limit, 500/s is burst limit
 	})
 	kclProcess.Run()
 }

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -158,8 +158,9 @@ func main() {
 	config := firehose.FirehoseWriterConfig{
 		StreamName:    getEnv("FIREHOSE_STREAM_NAME"),
 		Region:        getEnv("FIREHOSE_AWS_REGION"),
-		FlushInterval: 30000,
+		FlushInterval: 10 * time.Second,
 		FlushCount:    500,
+		FlushSize:     4 * 1024 * 1024, // 4Mb
 	}
 	writer, err := firehose.NewFirehoseWriter(config, "")
 	if err != nil {

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -158,8 +158,8 @@ func main() {
 	config := firehose.FirehoseWriterConfig{
 		StreamName:    getEnv("FIREHOSE_STREAM_NAME"),
 		Region:        getEnv("FIREHOSE_AWS_REGION"),
-		FlushInterval: 10000,
-		FlushCount:    100,
+		FlushInterval: 30000,
+		FlushCount:    500,
 	}
 	writer, err := firehose.NewFirehoseWriter(config, "")
 	if err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: eadbb4139b0f7ed13492e7071071f0d918dbb75f9e0078c36569a1838a27a7ce
-updated: 2017-03-17T14:46:42.034385318-07:00
+hash: 22ca6a3bbe1177f204bf4c58c85778853104fa6d06a4879ab1229fd5e41352db
+updated: 2017-03-22T16:23:18.301726515-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: f70a8a7d8680992d62277dc6bd76e32a08152ac1
+  version: 819b71cf8430e434c1eee7e7e8b0f2b8870be899
   subpackages:
   - aws
   - aws/awserr
@@ -35,7 +35,7 @@ imports:
   subpackages:
   - kcl
 - name: github.com/Clever/heka-clever-plugins
-  version: a6c5c23afaca604477ea2a6fc609f1882eae5568
+  version: fd3e18929e81329237f543bdc2b63f214b618305
   subpackages:
   - aws
   - batcher
@@ -47,8 +47,28 @@ imports:
   - gomock
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: golang.org/x/net
+  version: b336a971b799939dd16ae9b1df8334cb8b977c4d
+  subpackages:
+  - context
+- name: golang.org/x/time
+  version: f51c12702a4d776e4c1fa9b0fabab841babae631
+  subpackages:
+  - rate
 - name: gopkg.in/Clever/kayvee-go.v3
   version: 056c92dcc68b40c5d6045f755197b3776f914154
   subpackages:
   - logger
-testImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,6 @@ import:
   - aws
   - batcher
 - package: github.com/aws/aws-sdk-go
+- package: golang.org/x/time
+  subpackages:
+  - rate

--- a/launch/kinesis-to-firehose.yml
+++ b/launch/kinesis-to-firehose.yml
@@ -7,6 +7,7 @@ env:
 - FIREHOSE_AWS_REGION
 - FIREHOSE_STREAM_NAME
 - LOG_FILE
+- RATE_LIMIT
 resources:
   cpu: 1.0
   max_mem: 2.0


### PR DESCRIPTION
Issue: https://clever.atlassian.net/browse/INFRA-2209

Previously, we weren't using the batcher correctly, so it was sending batches of 10 records-per-batch 😨 Now we are sending larger batches, that reflect Firehose API limits for a single call to `putRecordsBatch`.

Once this was enabled, we quickly began spamming Firehose. In order to combat that, I've added rate limiting, so you can throttle the speed at which records are read from the input stream.