### PR TITLE
Refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,10 @@ run_kinesis_consumer: consumer_properties
 	command -v java >/dev/null 2>&1 || { echo >&2 "Java not installed. Install java!"; exit 1; }
 	java -cp $(JAVA_CLASS_PATH) com.amazonaws.services.kinesis.multilang.MultiLangDaemon consumer.properties
 
-run: build download_jars run_kinesis_consumer
+run:
+	GOOS=linux GOARCH=amd64 make build
+	docker build -t kinesis-to-firehose .
+	docker run --env-file=<(echo -e $(_ARKLOC_ENV_FILE)) kinesis-to-firehose
 
 test:
 	echo "no tests :("

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -143,7 +143,7 @@ func appendToFile(filename, text string) error {
 func (rp *RecordProcessor) Shutdown(checkpointer kcl.Checkpointer, reason string) error {
 	if reason == "TERMINATE" {
 		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
-		rp.firehoseWriter.Shutdown()
+		rp.firehoseWriter.FlushAll()
 		rp.checkpoint(checkpointer, "", 0)
 	} else {
 		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Reason: %s. Will not checkpoint.\n", reason)

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -118,7 +118,7 @@ func (rp *RecordProcessor) ProcessRecords(records []kcl.Record, checkpointer kcl
 		rp.lastCheckpoint = time.Now()
 
 		// Write status to file
-		err := appendToFile(logFile, fmt.Sprintf("%s -- %+v\n", rp.shardID, rp.firehoseWriter.Status()))
+		err := appendToFile(logFile, fmt.Sprintf("%s -- %s\n", rp.shardID, rp.firehoseWriter.Status()))
 		if err != nil {
 			return err
 		}
@@ -143,7 +143,7 @@ func appendToFile(filename, text string) error {
 func (rp *RecordProcessor) Shutdown(checkpointer kcl.Checkpointer, reason string) error {
 	if reason == "TERMINATE" {
 		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
-		rp.firehoseWriter.FlushAll()
+		rp.firehoseWriter.Shutdown()
 		rp.checkpoint(checkpointer, "", 0)
 	} else {
 		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Reason: %s. Will not checkpoint.\n", reason)
@@ -169,7 +169,7 @@ func main() {
 		FlushCount:    500,
 		FlushSize:     4 * 1024 * 1024, // 4Mb
 	}
-	writer, err := firehose.NewFirehoseWriter(config, "")
+	writer, err := firehose.NewFirehoseWriter(config)
 	if err != nil {
 		log.Fatalf("Failed to create FirehoseWriter: %s", err.Error())
 	}

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Clever/amazon-kinesis-client-go/kcl"
 	"golang.org/x/time/rate"
 
-	"github.com/Clever/kinesis-to-firehose/firehose"
+	"github.com/Clever/kinesis-to-firehose/writer"
 )
 
 type RecordProcessor struct {
@@ -24,7 +24,7 @@ type RecordProcessor struct {
 	largestSeq        *big.Int
 	largestSubSeq     int
 	lastCheckpoint    time.Time
-	firehoseWriter    *firehose.FirehoseWriter
+	firehoseWriter    *writer.FirehoseWriter
 	rateLimiter       *rate.Limiter // Limits the number of records processed per second
 }
 
@@ -162,14 +162,14 @@ func main() {
 	}
 	defer f.Close()
 
-	config := firehose.FirehoseWriterConfig{
+	config := writer.FirehoseWriterConfig{
 		StreamName:    getEnv("FIREHOSE_STREAM_NAME"),
 		Region:        getEnv("FIREHOSE_AWS_REGION"),
 		FlushInterval: 10 * time.Second,
 		FlushCount:    500,
 		FlushSize:     4 * 1024 * 1024, // 4Mb
 	}
-	writer, err := firehose.NewFirehoseWriter(config)
+	writer, err := writer.NewFirehoseWriter(config)
 	if err != nil {
 		log.Fatalf("Failed to create FirehoseWriter: %s", err.Error())
 	}

--- a/firehose/firehose_kinesis.go
+++ b/firehose/firehose_kinesis.go
@@ -113,7 +113,7 @@ func (f *FirehoseWriter) Status() string {
 	return fmt.Sprintf("Received:%d Sent:%d Failed:%d", f.recvRecordCount, f.sentRecordCount, f.failedRecordCount)
 }
 
-// Shutdown flushes all remaining messages in the batcher.
-func (f *FirehoseWriter) Shutdown() {
+// FlushAll flushes all remaining messages in the batcher.
+func (f *FirehoseWriter) FlushAll() {
 	f.messageBatcher.Flush()
 }

--- a/firehose/firehose_kinesis.go
+++ b/firehose/firehose_kinesis.go
@@ -26,17 +26,15 @@ type FirehoseWriter struct {
 
 // FirehoseWriterConfig is the set of config options used in NewFirehoseWriter
 type FirehoseWriterConfig struct {
-	// The value of this field is used as the firehose stream name
+	// StreamName is the firehose stream name
 	StreamName string
-	// AWS region the firehose stream lives in
+	// Region is the AWS region the firehose stream lives in
 	Region string
-	// Interval at which accumulated messages should be bulk put to firehose
+	// FlushInterval is how often accumulated messages should be bulk put to firehose
 	FlushInterval time.Duration
-	// Number of messages that triggers a push to firehose
-	// Max is 500, see: http://docs.aws.amazon.com/firehose/latest/dev/limits.html
+	// FlushCount is the number of messages that triggers a push to firehose. Max batch size is 500, see: http://docs.aws.amazon.com/firehose/latest/dev/limits.html
 	FlushCount int
-	// Size of batch that triggers a push to firehose
-	// Max is 4Mb (4*1024*1024), see: http://docs.aws.amazon.com/firehose/latest/dev/limits.html
+	// FlushSize is the size of a batch in bytes that triggers a push to firehose. Max batch size is 4Mb (4*1024*1024), see: http://docs.aws.amazon.com/firehose/latest/dev/limits.html
 	FlushSize int
 }
 

--- a/writer/firehose_writer.go
+++ b/writer/firehose_writer.go
@@ -11,13 +11,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/firehose"
+	iface "github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
 )
 
 // FirehoseWriter writes record batches to a firehose stream
 type FirehoseWriter struct {
 	streamName     string
 	messageBatcher batcher.Batcher
-	firehoseClient *firehose.Firehose
+	firehoseClient iface.FirehoseAPI
 
 	recvRecordCount   int64
 	sentRecordCount   int64


### PR DESCRIPTION
Various refactoring, including...

- moves firehose logic that was previously in heka-clever-plugins.
    - uses retries in aws-sdk-go client instead of retry logic we wrote
- adds better docs
- writes to exactly one stream (no need for multiple streams given
  s3archive use case)
- removes syncPutterAdpter (now the FirehoseWriter itself implements the
  batch interface)
- simplifies `Status` method to return a string
- remove mocking (was unused)
- avoids overly verbose error logging from heka-clever-plugins/aws/firehose https://github.com/Clever/heka-clever-plugins/blob/master/aws/firehose.go#L78-L89