### PR TITLE
Fix checkpointing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ run_kinesis_consumer: consumer_properties
 run:
 	GOOS=linux GOARCH=amd64 make build
 	docker build -t kinesis-to-firehose .
-	docker run --env-file=<(echo -e $(_ARKLOC_ENV_FILE)) kinesis-to-firehose
+	docker run -v /tmp:/tmp --env-file=<(echo -e $(_ARKLOC_ENV_FILE)) kinesis-to-firehose
 
 test:
 	echo "no tests :("

--- a/README.md
+++ b/README.md
@@ -26,4 +26,7 @@ This will download the jar files necessary to run the KCL, and then launch the K
 
 ### Running at Clever
 
-You can also use `ark` to run locally, via `ark start --local`
+You can also use `ark` to run locally, via `ark start --local`.
+
+Note: In addition to output from the process, you may want to run `tail -f /tmp/kcl_stderr` to view more logs written to file.
+These logs aren't written to stdout/stderr, since KCL uses those for communication.

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -48,7 +48,7 @@ func (rp *RecordProcessor) Initialize(shardID string) error {
 }
 
 func (rp *RecordProcessor) checkpoint(checkpointer kcl.Checkpointer, sequenceNumber string, subSequenceNumber int) {
-	for n := 0; n < rp.checkpointRetries; n++ {
+	for n := -1; n < rp.checkpointRetries; n++ {
 		err := checkpointer.Checkpoint(sequenceNumber, subSequenceNumber)
 		if err == nil {
 			return
@@ -68,7 +68,7 @@ func (rp *RecordProcessor) checkpoint(checkpointer kcl.Checkpointer, sequenceNum
 			}
 		}
 
-		if n == rp.checkpointRetries-1 {
+		if n == rp.checkpointRetries {
 			fmt.Fprintf(os.Stderr, "Failed to checkpoint after %d attempts, giving up.\n", rp.checkpointRetries)
 			return
 		}


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2209

Previously, the default # retries was 0, which actually results in 0 total attempts.

I changed the logic so that there's always at least 1 attempt, followed by retries.

Additionally, I setup the RecordProcessor using `NewRecordProcessor`, so it has default configuration instead of ~null configuration.