### PR TITLE
Refactor. Update to only checkpoint flushed messages

### DIFF
--- a/batcher/message_batcher.go
+++ b/batcher/message_batcher.go
@@ -2,11 +2,13 @@ package batcher
 
 import (
 	"fmt"
+	"math/big"
+	"os"
 	"time"
 )
 
 type Sync interface {
-	Flush(batch [][]byte)
+	SendBatch(batch [][]byte, largestSeq *big.Int, largetsSubSeq int)
 }
 
 type Batcher interface {
@@ -20,8 +22,10 @@ type Batcher interface {
 	// default to 1mb (1024 * 1024)
 	FlushSize(size int)
 
-	// Messages for length 0 are ignored
-	AddMessage(msg []byte) error
+	//AddMesage to the batch
+	AddMessage(msg []byte, sequenceNumber string, subSequenceNumber int) error
+
+	//Flush all messages from the batch
 	Flush()
 }
 
@@ -29,6 +33,9 @@ type batcher struct {
 	flushInterval time.Duration
 	flushCount    int
 	flushSize     int
+
+	largestSeq    *big.Int
+	largestSubSeq int
 
 	sync      Sync
 	msgChan   chan<- []byte
@@ -66,13 +73,29 @@ func (b *batcher) FlushSize(size int) {
 	b.flushSize = size
 }
 
-func (b *batcher) AddMessage(msg []byte) error {
+func (b *batcher) AddMessage(msg []byte, sequenceNumber string, subSequenceNumber int) error {
 	if len(msg) <= 0 {
 		return fmt.Errorf("Empty messages can't be sent")
 	}
 
 	b.msgChan <- msg
+	b.updateSequenceNumber(sequenceNumber, subSequenceNumber)
 	return nil
+}
+
+// updateSequenceNumber updates sequence number on the batch, if a larger one is available
+func (b *batcher) updateSequenceNumber(sequenceNumber string, subSequenceNumber int) {
+	seqNumBig := new(big.Int)
+	if _, ok := seqNumBig.SetString(sequenceNumber, 10); !ok {
+		fmt.Fprintf(os.Stderr, "could not parse sequence number '%s'\n", sequenceNumber)
+		return
+	}
+
+	// Check if new seqNumBig is larger
+	if b.largestSeq == nil || seqNumBig.Cmp(b.largestSeq) == 1 || (seqNumBig.Cmp(b.largestSeq) == 0 && subSequenceNumber > b.largestSubSeq) {
+		b.largestSeq = seqNumBig
+		b.largestSubSeq = subSequenceNumber
+	}
 }
 
 func (b *batcher) Flush() {
@@ -88,9 +111,9 @@ func (b *batcher) batchSize(batch [][]byte) int {
 	return total
 }
 
-func (b *batcher) sendBatch(batch [][]byte) [][]byte {
+func (b *batcher) flush(batch [][]byte) [][]byte {
 	if len(batch) > 0 {
-		b.sync.Flush(batch)
+		b.sync.SendBatch(batch, b.largestSeq, b.largestSubSeq)
 	}
 	return [][]byte{}
 }
@@ -101,19 +124,19 @@ func (b *batcher) startBatcher(msgChan <-chan []byte, flushChan <-chan struct{})
 	for {
 		select {
 		case <-time.After(b.flushInterval):
-			batch = b.sendBatch(batch)
+			batch = b.flush(batch)
 		case <-flushChan:
-			batch = b.sendBatch(batch)
+			batch = b.flush(batch)
 		case msg := <-msgChan:
 			size := b.batchSize(batch)
 			if b.flushSize < size+len(msg) {
-				batch = b.sendBatch(batch)
+				batch = b.flush(batch)
 			}
 
 			batch = append(batch, msg)
 
 			if b.flushCount <= len(batch) || b.flushSize <= b.batchSize(batch) {
-				batch = b.sendBatch(batch)
+				batch = b.flush(batch)
 			}
 		}
 	}

--- a/batcher/message_batcher.go
+++ b/batcher/message_batcher.go
@@ -1,0 +1,120 @@
+package batcher
+
+import (
+	"fmt"
+	"time"
+)
+
+type Sync interface {
+	Flush(batch [][]byte)
+}
+
+type Batcher interface {
+	// Interval at which accumulated messages should be bulk put to
+	// firehose (default 1 second).
+	FlushInterval(dur time.Duration)
+	// Number of messages that triggers a push to firehose
+	// default to 10
+	FlushCount(count int)
+	// Size of batch that triggers a push to firehose
+	// default to 1mb (1024 * 1024)
+	FlushSize(size int)
+
+	// Messages for length 0 are ignored
+	AddMessage(msg []byte) error
+	Flush()
+}
+
+type batcher struct {
+	flushInterval time.Duration
+	flushCount    int
+	flushSize     int
+
+	sync      Sync
+	msgChan   chan<- []byte
+	flushChan chan<- struct{}
+}
+
+func New(sync Sync) *batcher {
+	msgChan := make(chan []byte, 100)
+	flushChan := make(chan struct{})
+
+	b := &batcher{
+		flushCount:    10,
+		flushInterval: time.Second,
+		flushSize:     1024 * 1024,
+
+		sync:      sync,
+		msgChan:   msgChan,
+		flushChan: flushChan,
+	}
+
+	go b.startBatcher(msgChan, flushChan)
+
+	return b
+}
+
+func (b *batcher) FlushInterval(dur time.Duration) {
+	b.flushInterval = dur
+}
+
+func (b *batcher) FlushCount(count int) {
+	b.flushCount = count
+}
+
+func (b *batcher) FlushSize(size int) {
+	b.flushSize = size
+}
+
+func (b *batcher) AddMessage(msg []byte) error {
+	if len(msg) <= 0 {
+		return fmt.Errorf("Empty messages can't be sent")
+	}
+
+	b.msgChan <- msg
+	return nil
+}
+
+func (b *batcher) Flush() {
+	b.flushChan <- struct{}{}
+}
+
+func (b *batcher) batchSize(batch [][]byte) int {
+	total := 0
+	for _, msg := range batch {
+		total += len(msg)
+	}
+
+	return total
+}
+
+func (b *batcher) sendBatch(batch [][]byte) [][]byte {
+	if len(batch) > 0 {
+		b.sync.Flush(batch)
+	}
+	return [][]byte{}
+}
+
+func (b *batcher) startBatcher(msgChan <-chan []byte, flushChan <-chan struct{}) {
+	batch := [][]byte{}
+
+	for {
+		select {
+		case <-time.After(b.flushInterval):
+			batch = b.sendBatch(batch)
+		case <-flushChan:
+			batch = b.sendBatch(batch)
+		case msg := <-msgChan:
+			size := b.batchSize(batch)
+			if b.flushSize < size+len(msg) {
+				batch = b.sendBatch(batch)
+			}
+
+			batch = append(batch, msg)
+
+			if b.flushCount <= len(batch) || b.flushSize <= b.batchSize(batch) {
+				batch = b.sendBatch(batch)
+			}
+		}
+	}
+}

--- a/batcher/message_batcher_test.go
+++ b/batcher/message_batcher_test.go
@@ -1,0 +1,186 @@
+package batcher
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type batch [][]byte
+
+type mockSync struct {
+	flushChan chan struct{}
+	batches   []batch
+}
+
+func NewMockSync() *mockSync {
+	return &mockSync{
+		flushChan: make(chan struct{}, 1),
+		batches:   []batch{},
+	}
+}
+
+func (m *mockSync) Flush(b [][]byte) {
+	m.batches = append(m.batches, batch(b))
+	m.flushChan <- struct{}{}
+}
+
+func (m *mockSync) waitForFlush(timeout time.Duration) error {
+	select {
+	case <-m.flushChan:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("The flush never came.  I waited %s.", timeout.String())
+	}
+}
+
+func TestBatchingByCount(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Hour)
+	batcher.FlushCount(2)
+
+	t.Log("Batcher respect count limit")
+	assert.NoError(batcher.Send([]byte("hihi")))
+	assert.NoError(batcher.Send([]byte("heyhey")))
+	assert.NoError(batcher.Send([]byte("hmmhmm"))) // Shouldn't be in first batch
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(2, len(sync.batches[0]))
+	assert.Equal("hihi", string(sync.batches[0][0]))
+	assert.Equal("heyhey", string(sync.batches[0][1]))
+
+	t.Log("Batcher doesn't send partial batches")
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+}
+
+func TestBatchingByTime(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Millisecond)
+	batcher.FlushCount(2000000)
+
+	t.Log("Batcher sends partial batches when time expires")
+	assert.NoError(batcher.Send([]byte("hihi")))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal("hihi", string(sync.batches[0][0]))
+
+	t.Log("Batcher sends all messsages in partial batches when time expires")
+	assert.NoError(batcher.Send([]byte("heyhey")))
+	assert.NoError(batcher.Send([]byte("yoyo")))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(2, len(sync.batches))
+	assert.Equal(2, len(sync.batches[1]))
+	assert.Equal("heyhey", string(sync.batches[1][0]))
+	assert.Equal("yoyo", string(sync.batches[1][1]))
+
+	t.Log("Batcher doesn't send empty batches")
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+}
+
+func TestBatchingBySize(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Hour)
+	batcher.FlushCount(2000000)
+	batcher.FlushSize(8)
+
+	t.Log("Large messages are sent immediately")
+	assert.NoError(batcher.Send([]byte("hellohello")))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal("hellohello", string(sync.batches[0][0]))
+
+	t.Log("Batcher tries not to exceed size limit")
+	assert.NoError(batcher.Send([]byte("heyhey")))
+	assert.NoError(batcher.Send([]byte("hihi")))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(2, len(sync.batches))
+	assert.Equal(1, len(sync.batches[1]))
+	assert.Equal("heyhey", string(sync.batches[1][0]))
+
+	t.Log("Batcher sends messages that didn't fit in previous batch")
+	assert.NoError(batcher.Send([]byte("yoyo"))) // At this point "hihi" is in the batch
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(3, len(sync.batches))
+	assert.Equal(2, len(sync.batches[2]))
+	assert.Equal("hihi", string(sync.batches[2][0]))
+	assert.Equal("yoyo", string(sync.batches[2][1]))
+
+	t.Log("Batcher doesn't send partial batches")
+	assert.NoError(batcher.Send([]byte("okok")))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+}
+
+func TestFlushing(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+	batcher.FlushInterval(time.Hour)
+	batcher.FlushCount(2000000)
+
+	t.Log("Calling flush sends pending messages")
+	assert.NoError(batcher.Send([]byte("hihi")))
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.Error(err)
+
+	batcher.Flush()
+
+	err = sync.waitForFlush(time.Millisecond * 10)
+	assert.NoError(err)
+
+	assert.Equal(1, len(sync.batches))
+	assert.Equal(1, len(sync.batches[0]))
+	assert.Equal("hihi", string(sync.batches[0][0]))
+}
+
+func TestSendingEmpty(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	sync := NewMockSync()
+	batcher := New(sync)
+
+	t.Log("An error is returned when an empty message is sent")
+	err = batcher.Send([]byte{})
+	assert.Error(err)
+}

--- a/batcher/message_batcher_test.go
+++ b/batcher/message_batcher_test.go
@@ -48,8 +48,8 @@ func TestBatchingByCount(t *testing.T) {
 
 	sync := NewMockSync()
 	batcher := New(sync)
-	batcher.FlushInterval(time.Hour)
-	batcher.FlushCount(2)
+	batcher.SetFlushInterval(time.Hour)
+	batcher.SetFlushCount(2)
 
 	t.Log("Batcher respect count limit")
 	assert.NoError(batcher.AddMessage([]byte("hihi"), mockSequenceNumber, mockSubSequenceNumber))
@@ -75,8 +75,8 @@ func TestBatchingByTime(t *testing.T) {
 
 	sync := NewMockSync()
 	batcher := New(sync)
-	batcher.FlushInterval(time.Millisecond)
-	batcher.FlushCount(2000000)
+	batcher.SetFlushInterval(time.Millisecond)
+	batcher.SetFlushCount(2000000)
 
 	t.Log("Batcher sends partial batches when time expires")
 	assert.NoError(batcher.AddMessage([]byte("hihi"), mockSequenceNumber, mockSubSequenceNumber))
@@ -111,9 +111,9 @@ func TestBatchingBySize(t *testing.T) {
 
 	sync := NewMockSync()
 	batcher := New(sync)
-	batcher.FlushInterval(time.Hour)
-	batcher.FlushCount(2000000)
-	batcher.FlushSize(8)
+	batcher.SetFlushInterval(time.Hour)
+	batcher.SetFlushCount(2000000)
+	batcher.SetFlushSize(8)
 
 	t.Log("Large messages are sent immediately")
 	assert.NoError(batcher.AddMessage([]byte("hellohello"), mockSequenceNumber, mockSubSequenceNumber))
@@ -160,8 +160,8 @@ func TestFlushing(t *testing.T) {
 
 	sync := NewMockSync()
 	batcher := New(sync)
-	batcher.FlushInterval(time.Hour)
-	batcher.FlushCount(2000000)
+	batcher.SetFlushInterval(time.Hour)
+	batcher.SetFlushCount(2000000)
 
 	t.Log("Calling flush sends pending messages")
 	assert.NoError(batcher.AddMessage([]byte("hihi"), mockSequenceNumber, mockSubSequenceNumber))
@@ -195,9 +195,7 @@ func TestUpdatingSequence(t *testing.T) {
 	assert := assert.New(t)
 
 	sync := NewMockSync()
-	batcher := New(sync)
-
-	t.Log("An error is returned when an empty message is sent")
+	batcher := New(sync).(*batcher)
 
 	t.Log("Initally, largestSeq is undefined")
 	expected := new(big.Int)

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"context"
-	"encoding/base64"
-	"fmt"
 	"log"
-	"math/big"
 	"os"
 	"strconv"
 	"time"
@@ -18,140 +14,6 @@ import (
 
 	"github.com/Clever/kinesis-to-firehose/writer"
 )
-
-type RecordProcessor struct {
-	shardID           string
-	sleepDuration     time.Duration
-	checkpointRetries int
-	checkpointFreq    time.Duration
-	largestSeq        *big.Int
-	largestSubSeq     int
-	lastCheckpoint    time.Time
-	firehoseWriter    *writer.FirehoseWriter
-	rateLimiter       *rate.Limiter // Limits the number of records processed per second
-}
-
-func NewRecordProcessor(writer *writer.FirehoseWriter, limiter *rate.Limiter) *RecordProcessor {
-	return &RecordProcessor{
-		sleepDuration:     5 * time.Second,
-		checkpointRetries: 5,
-		checkpointFreq:    60 * time.Second,
-		firehoseWriter:    writer,
-		rateLimiter:       limiter,
-	}
-}
-
-func (rp *RecordProcessor) Initialize(shardID string) error {
-	rp.shardID = shardID
-	rp.lastCheckpoint = time.Now()
-	return nil
-}
-
-func (rp *RecordProcessor) checkpoint(checkpointer kcl.Checkpointer, sequenceNumber string, subSequenceNumber int) {
-	for n := -1; n < rp.checkpointRetries; n++ {
-		err := checkpointer.Checkpoint(sequenceNumber, subSequenceNumber)
-		if err == nil {
-			return
-		}
-
-		if cperr, ok := err.(kcl.CheckpointError); ok {
-			switch cperr.Error() {
-			case "ShutdownException":
-				fmt.Fprintf(os.Stderr, "Encountered shutdown exception, skipping checkpoint\n")
-				return
-			case "ThrottlingException":
-				fmt.Fprintf(os.Stderr, "Was throttled while checkpointing, will attempt again in %s", rp.sleepDuration)
-			case "InvalidStateException":
-				fmt.Fprintf(os.Stderr, "MultiLangDaemon reported an invalid state while checkpointing\n")
-			default:
-				fmt.Fprintf(os.Stderr, "Encountered an error while checkpointing: %s", err)
-			}
-		}
-
-		if n == rp.checkpointRetries {
-			fmt.Fprintf(os.Stderr, "Failed to checkpoint after %d attempts, giving up.\n", rp.checkpointRetries)
-			return
-		}
-
-		time.Sleep(rp.sleepDuration)
-	}
-}
-
-// shouldUpdateSequence determines whether a new larger sequence number is available
-func (rp *RecordProcessor) shouldUpdateSequence(sequenceNumber *big.Int, subSequenceNumber int) bool {
-	return rp.largestSeq == nil || sequenceNumber.Cmp(rp.largestSeq) == 1 ||
-		(sequenceNumber.Cmp(rp.largestSeq) == 0 && subSequenceNumber > rp.largestSubSeq)
-}
-
-func (rp *RecordProcessor) ProcessRecords(records []kcl.Record, checkpointer kcl.Checkpointer) error {
-	for _, record := range records {
-		// Wait until rate limiter permits one record to be processed
-		rp.rateLimiter.Wait(context.Background())
-
-		// Base64 decode the record
-		data, err := base64.StdEncoding.DecodeString(record.Data)
-		if err != nil {
-			return err
-		}
-		msg := string(data)
-
-		// Write the message to firehose
-		err = rp.firehoseWriter.ProcessMessage(msg)
-		if err != nil {
-			return err
-		}
-
-		// Handle checkpointing
-		// TODO: How to handle the difference between ProcessMessage (sent to FirehoseOutput) vs successfully sent?
-		seqNumber := new(big.Int)
-		if _, ok := seqNumber.SetString(record.SequenceNumber, 10); !ok {
-			fmt.Fprintf(os.Stderr, "could not parse sequence number '%s'\n", record.SequenceNumber)
-			continue
-		}
-		if rp.shouldUpdateSequence(seqNumber, record.SubSequenceNumber) {
-			rp.largestSeq = seqNumber
-			rp.largestSubSeq = record.SubSequenceNumber
-		}
-	}
-	if time.Now().Sub(rp.lastCheckpoint) > rp.checkpointFreq {
-		rp.checkpoint(checkpointer, rp.largestSeq.String(), rp.largestSubSeq)
-		rp.lastCheckpoint = time.Now()
-
-		// Write status to file
-		err := appendToFile(logFile, fmt.Sprintf("%s -- %s\n", rp.shardID, rp.firehoseWriter.Status()))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func appendToFile(filename, text string) error {
-	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if _, err = f.WriteString(text); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (rp *RecordProcessor) Shutdown(checkpointer kcl.Checkpointer, reason string) error {
-	if reason == "TERMINATE" {
-		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
-		rp.firehoseWriter.FlushAll()
-		rp.checkpoint(checkpointer, "", 0)
-	} else {
-		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Reason: %s. Will not checkpoint.\n", reason)
-	}
-	return nil
-}
-
-var logFile = "/tmp/kcl_stderr"
 
 func main() {
 	logFile := getEnv("LOG_FILE")
@@ -169,10 +31,7 @@ func main() {
 		FlushInterval:  10 * time.Second,
 		FlushCount:     500,
 		FlushSize:      4 * 1024 * 1024, // 4Mb
-	}
-	writer, err := writer.NewFirehoseWriter(config)
-	if err != nil {
-		log.Fatalf("Failed to create FirehoseWriter: %s", err.Error())
+		LogFile:        logFile,
 	}
 
 	// rateLimit is expressed in records-per-second
@@ -184,8 +43,11 @@ func main() {
 	rateLimit := rate.Limit(rl)
 	burstLimit := int(rl * 1.2)
 
-	rp := NewRecordProcessor(writer, rate.NewLimiter(rateLimit, burstLimit))
-	kclProcess := kcl.New(os.Stdin, os.Stdout, os.Stderr, rp)
+	writer, err := writer.NewFirehoseWriter(config, rate.NewLimiter(rateLimit, burstLimit))
+	if err != nil {
+		log.Fatalf("Failed to create FirehoseWriter: %s", err.Error())
+	}
+	kclProcess := kcl.New(os.Stdin, os.Stdout, os.Stderr, writer)
 	kclProcess.Run()
 }
 

--- a/writer/firehose_writer.go
+++ b/writer/firehose_writer.go
@@ -1,23 +1,43 @@
 package writer
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"os"
 	"sync/atomic"
 	"time"
 
+	"github.com/Clever/amazon-kinesis-client-go/kcl"
 	"github.com/Clever/heka-clever-plugins/batcher"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	iface "github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
+	"golang.org/x/time/rate"
 )
 
-// FirehoseWriter writes record batches to a firehose stream
 type FirehoseWriter struct {
+	shardID string
+	logFile string
+
+	// KCL checkpointing
+	sleepDuration     time.Duration
+	checkpointRetries int
+	checkpointFreq    time.Duration
+	largestSeq        *big.Int
+	largestSubSeq     int
+	lastCheckpoint    time.Time
+
+	// Limits the number of records processed per second
+	rateLimiter *rate.Limiter
+
+	// Firehose Config
 	streamName     string
 	messageBatcher batcher.Batcher
 	firehoseClient iface.FirehoseAPI
 
+	// Firehose metrics
 	recvRecordCount   int64
 	sentRecordCount   int64
 	failedRecordCount int64
@@ -35,10 +55,11 @@ type FirehoseWriterConfig struct {
 	FlushCount int
 	// FlushSize is the size of a batch in bytes that triggers a push to firehose. Max batch size is 4Mb (4*1024*1024), see: http://docs.aws.amazon.com/firehose/latest/dev/limits.html
 	FlushSize int
+	// LogFile is the path to a log file (we write logs in a file since stdout/stderr are used by KCL)
+	LogFile string
 }
 
-// NewFirehoseWriter constructs a FirehoseWriter
-func NewFirehoseWriter(config FirehoseWriterConfig) (*FirehoseWriter, error) {
+func NewFirehoseWriter(config FirehoseWriterConfig, limiter *rate.Limiter) (*FirehoseWriter, error) {
 	if config.FlushCount > 500 || config.FlushCount < 1 {
 		return nil, fmt.Errorf("FlushCount must be between 1 and 500 messages")
 	}
@@ -47,8 +68,13 @@ func NewFirehoseWriter(config FirehoseWriterConfig) (*FirehoseWriter, error) {
 	}
 
 	f := &FirehoseWriter{
-		streamName:     config.StreamName,
-		firehoseClient: config.FirehoseClient,
+		streamName:        config.StreamName,
+		firehoseClient:    config.FirehoseClient,
+		sleepDuration:     5 * time.Second,
+		checkpointRetries: 5,
+		checkpointFreq:    60 * time.Second,
+		rateLimiter:       limiter,
+		logFile:           config.LogFile,
 	}
 
 	f.messageBatcher = batcher.New(f)
@@ -59,8 +85,118 @@ func NewFirehoseWriter(config FirehoseWriterConfig) (*FirehoseWriter, error) {
 	return f, nil
 }
 
+func (f *FirehoseWriter) Initialize(shardID string) error {
+	f.shardID = shardID
+	f.lastCheckpoint = time.Now()
+	return nil
+}
+
+// TODO: refactor KCL checkpointer to include retries / sleep duration
+func (f *FirehoseWriter) checkpoint(checkpointer kcl.Checkpointer, sequenceNumber string, subSequenceNumber int) {
+	for n := -1; n < f.checkpointRetries; n++ {
+		err := checkpointer.Checkpoint(sequenceNumber, subSequenceNumber)
+		if err == nil {
+			return
+		}
+
+		if cperr, ok := err.(kcl.CheckpointError); ok {
+			switch cperr.Error() {
+			case "ShutdownException":
+				fmt.Fprintf(os.Stderr, "Encountered shutdown exception, skipping checkpoint\n")
+				return
+			case "ThrottlingException":
+				fmt.Fprintf(os.Stderr, "Was throttled while checkpointing, will attempt again in %s", f.sleepDuration)
+			case "InvalidStateException":
+				fmt.Fprintf(os.Stderr, "MultiLangDaemon reported an invalid state while checkpointing\n")
+			default:
+				fmt.Fprintf(os.Stderr, "Encountered an error while checkpointing: %s", err)
+			}
+		}
+
+		if n == f.checkpointRetries {
+			fmt.Fprintf(os.Stderr, "Failed to checkpoint after %d attempts, giving up.\n", f.checkpointRetries)
+			return
+		}
+
+		time.Sleep(f.sleepDuration)
+	}
+}
+
+// shouldUpdateSequence determines whether a new larger sequence number is available
+func (f *FirehoseWriter) shouldUpdateSequence(sequenceNumber *big.Int, subSequenceNumber int) bool {
+	return f.largestSeq == nil || sequenceNumber.Cmp(f.largestSeq) == 1 ||
+		(sequenceNumber.Cmp(f.largestSeq) == 0 && subSequenceNumber > f.largestSubSeq)
+}
+
+func (f *FirehoseWriter) ProcessRecords(records []kcl.Record, checkpointer kcl.Checkpointer) error {
+	for _, record := range records {
+		// Wait until rate limiter permits one record to be processed
+		f.rateLimiter.Wait(context.Background())
+
+		// Base64 decode the record
+		data, err := base64.StdEncoding.DecodeString(record.Data)
+		if err != nil {
+			return err
+		}
+		msg := string(data)
+
+		// Write the message to firehose
+		err = f.processMessage(msg)
+		if err != nil {
+			return err
+		}
+
+		// Handle checkpointing
+		seqNumber := new(big.Int)
+		if _, ok := seqNumber.SetString(record.SequenceNumber, 10); !ok {
+			fmt.Fprintf(os.Stderr, "could not parse sequence number '%s'\n", record.SequenceNumber)
+			continue
+		}
+		if f.shouldUpdateSequence(seqNumber, record.SubSequenceNumber) {
+			f.largestSeq = seqNumber
+			f.largestSubSeq = record.SubSequenceNumber
+		}
+	}
+	if time.Now().Sub(f.lastCheckpoint) > f.checkpointFreq {
+		f.checkpoint(checkpointer, f.largestSeq.String(), f.largestSubSeq)
+		f.lastCheckpoint = time.Now()
+
+		// Write status to file
+		err := appendToFile(f.logFile, fmt.Sprintf("%s -- %s\n", f.shardID, f.Status()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendToFile(filename, text string) error {
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err = f.WriteString(text); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f *FirehoseWriter) Shutdown(checkpointer kcl.Checkpointer, reason string) error {
+	if reason == "TERMINATE" {
+		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
+		f.FlushAll()
+		f.checkpoint(checkpointer, "", 0)
+	} else {
+		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Reason: %s. Will not checkpoint.\n", reason)
+	}
+	return nil
+}
+
 // ProcessMessage reads an input string and adds it to the batcher, which will ultimately send it
-func (f *FirehoseWriter) ProcessMessage(msg string) error {
+func (f *FirehoseWriter) processMessage(msg string) error {
 	atomic.AddInt64(&f.recvRecordCount, 1)
 
 	// TODO: Fully decode the message

--- a/writer/firehose_writer.go
+++ b/writer/firehose_writer.go
@@ -79,9 +79,9 @@ func NewFirehoseWriter(config FirehoseWriterConfig, limiter *rate.Limiter) (*Fir
 	}
 
 	f.messageBatcher = batcher.New(f)
-	f.messageBatcher.FlushCount(config.FlushCount)
-	f.messageBatcher.FlushInterval(config.FlushInterval)
-	f.messageBatcher.FlushSize(config.FlushSize)
+	f.messageBatcher.SetFlushCount(config.FlushCount)
+	f.messageBatcher.SetFlushInterval(config.FlushInterval)
+	f.messageBatcher.SetFlushSize(config.FlushSize)
 
 	return f, nil
 }
@@ -171,6 +171,7 @@ func (f *FirehoseWriter) processRecord(record kcl.Record) error {
 func (f *FirehoseWriter) Shutdown(checkpointer kcl.Checkpointer, reason string) error {
 	if reason == "TERMINATE" {
 		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
+		f.messageBatcher.Flush()
 		f.checkpoint(checkpointer, "", 0)
 	} else {
 		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Reason: %s. Will not checkpoint.\n", reason)

--- a/writer/firehose_writer.go
+++ b/writer/firehose_writer.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Clever/amazon-kinesis-client-go/kcl"
-	"github.com/Clever/heka-clever-plugins/batcher"
+	"github.com/Clever/kinesis-to-firehose/batcher"
 	"github.com/aws/aws-sdk-go/service/firehose"
 	iface "github.com/aws/aws-sdk-go/service/firehose/firehoseiface"
 	"golang.org/x/time/rate"
@@ -210,7 +210,7 @@ func (f *FirehoseWriter) processMessage(msg string) error {
 		return err
 	}
 
-	return f.messageBatcher.Send(record)
+	return f.messageBatcher.AddMessage(record)
 }
 
 // Flush writes a batch of records to AWS Firehose


### PR DESCRIPTION
- Moves things out of `main` into `writer` package.
- Moves `batcher` from heka-clever-plugins into this repo, so we can change its interface to allow tracking progress in the Kinesis stream.
- Updates to only checkpoint flushed messages (details: 697a156)
