### PR TITLE
add option to stringify JSON log values

### DIFF
--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -28,6 +28,11 @@ func main() {
 	defer f.Close()
 	log.SetOutput(f)
 
+	stringifyNested := false
+	if os.Getenv("STRINGIFY_NESTED") == "1" {
+		stringifyNested = true
+	}
+
 	sess := session.Must(session.NewSession(aws.NewConfig().WithRegion(getEnv("FIREHOSE_AWS_REGION")).WithMaxRetries(4)))
 	config := writer.FirehoseWriterConfig{
 		FirehoseClient:    firehose.New(sess),
@@ -37,6 +42,7 @@ func main() {
 		FlushSize:         4 * 1024 * 1024, // 4Mb
 		LogFile:           logFile,
 		DeployEnvironment: getEnv("DEPLOY_ENV"),
+		StringifyNested:   stringifyNested,
 	}
 
 	// rateLimit is expressed in records-per-second

--- a/decode/decode.go
+++ b/decode/decode.go
@@ -96,7 +96,7 @@ func FieldsFromKayvee(line string) (map[string]interface{}, error) {
 }
 
 // ParseAndEnhance extracts fields from a log line, and does some post-processing to rename/add fields
-func ParseAndEnhance(line string, env string) (map[string]interface{}, error) {
+func ParseAndEnhance(line string, env string, stringifyNested bool) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 
 	syslogFields, err := FieldsFromSyslog(line)
@@ -144,6 +144,15 @@ func ParseAndEnhance(line string, env string) (map[string]interface{}, error) {
 	if err == nil {
 		for k, v := range meta {
 			out[k] = v
+		}
+	}
+
+	if stringifyNested {
+		for k, v := range out {
+			if obj, ok := v.(map[string]interface{}); ok {
+				bs, _ := json.Marshal(obj)
+				out[k] = string(bs)
+			}
 		}
 	}
 

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -183,6 +183,18 @@ func TestSyslogDecoding(t *testing.T) {
 	}
 }
 
+type ParseAndEnhanceInput struct {
+	Line            string
+	StringifyNested bool
+}
+
+type ParseAndEnhanceSpec struct {
+	Title          string
+	Input          ParseAndEnhanceInput
+	ExpectedOutput map[string]interface{}
+	ExpectedError  error
+}
+
 func TestParseAndEnhance(t *testing.T) {
 	// timestamp in Rsyslog_FileFormat
 	msPrecision := "2006-01-02T15:04:05.999999-07:00"
@@ -192,10 +204,10 @@ func TestParseAndEnhance(t *testing.T) {
 	}
 	logTime3 = logTime3.UTC()
 
-	specs := []Spec{
-		Spec{
+	specs := []ParseAndEnhanceSpec{
+		ParseAndEnhanceSpec{
 			Title: "Parses a Kayvee log line from an ECS app",
-			Input: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: 2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished"}`,
+			Input: ParseAndEnhanceInput{Line: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: 2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished"}`},
 			ExpectedOutput: map[string]interface{}{
 				"timestamp":      logTime3,
 				"hostname":       "ip-10-0-0-0",
@@ -212,9 +224,9 @@ func TestParseAndEnhance(t *testing.T) {
 			},
 			ExpectedError: nil,
 		},
-		Spec{
+		ParseAndEnhanceSpec{
 			Title: "Parses a Kayvee log line from an ECS app, with override to container_app",
-			Input: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: 2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished","container_app":"force-app"}`,
+			Input: ParseAndEnhanceInput{Line: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: 2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished","container_app":"force-app"}`},
 			ExpectedOutput: map[string]interface{}{
 				"timestamp":      logTime3,
 				"hostname":       "ip-10-0-0-0",
@@ -231,9 +243,9 @@ func TestParseAndEnhance(t *testing.T) {
 			},
 			ExpectedError: nil,
 		},
-		Spec{
+		ParseAndEnhanceSpec{
 			Title: "Parses a non-Kayvee log line",
-			Input: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: some log`,
+			Input: ParseAndEnhanceInput{Line: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: some log`},
 			ExpectedOutput: map[string]interface{}{
 				"timestamp":      logTime3,
 				"hostname":       "ip-10-0-0-0",
@@ -246,17 +258,60 @@ func TestParseAndEnhance(t *testing.T) {
 			},
 			ExpectedError: nil,
 		},
-		Spec{
+		ParseAndEnhanceSpec{
 			Title:          "Fails to parse non-RSyslog log line",
-			Input:          `not rsyslog`,
+			Input:          ParseAndEnhanceInput{Line: `not rsyslog`},
 			ExpectedOutput: map[string]interface{}{},
 			ExpectedError:  &syslogparser.ParserError{},
+		},
+		ParseAndEnhanceSpec{
+			Title: "Parses JSON values",
+			Input: ParseAndEnhanceInput{Line: `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: 2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished", "nested": {"a":"b"}}`},
+			ExpectedOutput: map[string]interface{}{
+				"timestamp":      logTime3,
+				"hostname":       "ip-10-0-0-0",
+				"programname":    `env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef`,
+				"rawlog":         `2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished", "nested": {"a":"b"}}`,
+				"title":          "request_finished",
+				"type":           "Kayvee",
+				"prefix":         "2017/04/05 21:57:46 some_file.go:10: ",
+				"postfix":        "",
+				"env":            "deploy-env",
+				"container_env":  "env",
+				"container_app":  "app",
+				"container_task": "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
+				"nested":         map[string]interface{}{"a": "b"},
+			},
+			ExpectedError: nil,
+		},
+		ParseAndEnhanceSpec{
+			Title: "Has the option to turn JSON values into strings",
+			Input: ParseAndEnhanceInput{
+				Line:            `2017-04-05T21:57:46.794862+00:00 ip-10-0-0-0 env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef[3291]: 2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished", "nested": {"a":"b"}}`,
+				StringifyNested: true,
+			},
+			ExpectedOutput: map[string]interface{}{
+				"timestamp":      logTime3,
+				"hostname":       "ip-10-0-0-0",
+				"programname":    `env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef`,
+				"rawlog":         `2017/04/05 21:57:46 some_file.go:10: {"title":"request_finished", "nested": {"a":"b"}}`,
+				"title":          "request_finished",
+				"type":           "Kayvee",
+				"prefix":         "2017/04/05 21:57:46 some_file.go:10: ",
+				"postfix":        "",
+				"env":            "deploy-env",
+				"container_env":  "env",
+				"container_app":  "app",
+				"container_task": "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
+				"nested":         `{"a":"b"}`,
+			},
+			ExpectedError: nil,
 		},
 	}
 	for _, spec := range specs {
 		t.Run(fmt.Sprintf(spec.Title), func(t *testing.T) {
 			assert := assert.New(t)
-			fields, err := ParseAndEnhance(spec.Input, "deploy-env")
+			fields, err := ParseAndEnhance(spec.Input.Line, "deploy-env", spec.Input.StringifyNested)
 			if spec.ExpectedError != nil {
 				assert.Error(err)
 				assert.IsType(spec.ExpectedError, err)
@@ -351,7 +406,7 @@ func BenchmarkFieldsFromSyslog(b *testing.B) {
 
 func BenchmarkParseAndEnhance(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		_, err := ParseAndEnhance(benchmarkLine, "env")
+		_, err := ParseAndEnhance(benchmarkLine, "env", false)
 		if err != nil {
 			b.FailNow()
 		}

--- a/launch/kinesis-to-firehose-log-archive.yml
+++ b/launch/kinesis-to-firehose-log-archive.yml
@@ -10,6 +10,7 @@ env:
 - LOG_FILE
 - RATE_LIMIT
 - DEPLOY_ENV
+- STRINGIFY_NESTED
 resources:
   cpu: .5
   max_mem: 1.8

--- a/launch/kinesis-to-firehose-log-search.yml
+++ b/launch/kinesis-to-firehose-log-search.yml
@@ -10,6 +10,7 @@ env:
 - LOG_FILE
 - RATE_LIMIT
 - DEPLOY_ENV
+- STRINGIFY_NESTED
 resources:
   cpu: .5
   max_mem: 1.8


### PR DESCRIPTION
In the current Elasticsearch setup for logs, we send nested JSON values as strings, not objects. This PR adds the option to replicate that behavior.