### PR TITLE
reject logs with timestamp < MinimumTimestamp

### DIFF
--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -39,6 +39,7 @@ func main() {
 	}
 
 	sess := session.Must(session.NewSession(aws.NewConfig().WithRegion(getEnv("FIREHOSE_AWS_REGION")).WithMaxRetries(4)))
+	minimumTimestamp, err := strconv.Atoi(getEnv("MINIMUM_TIMESTAMP"))
 	config := writer.FirehoseWriterConfig{
 		FirehoseClient:         firehose.New(sess),
 		StreamName:             getEnv("FIREHOSE_STREAM_NAME"),
@@ -49,6 +50,7 @@ func main() {
 		DeployEnvironment:      getEnv("DEPLOY_ENV"),
 		StringifyNested:        stringifyNested,
 		RenameESReservedFields: renameESReservedFields,
+		MinimumTimestamp:       time.Unix(int64(minimumTimestamp), 0),
 	}
 
 	// rateLimit is expressed in records-per-second

--- a/launch/kinesis-to-firehose-log-archive.yml
+++ b/launch/kinesis-to-firehose-log-archive.yml
@@ -12,6 +12,7 @@ env:
 - DEPLOY_ENV
 - STRINGIFY_NESTED
 - RENAME_ES_RESERVED_FIELDS
+- MINIMUM_TIMESTAMP
 resources:
   cpu: .5
   max_mem: 1.8

--- a/launch/kinesis-to-firehose-log-search.yml
+++ b/launch/kinesis-to-firehose-log-search.yml
@@ -12,6 +12,7 @@ env:
 - DEPLOY_ENV
 - STRINGIFY_NESTED
 - RENAME_ES_RESERVED_FIELDS
+- MINIMUM_TIMESTAMP
 resources:
   cpu: .5
   max_mem: 1.8

--- a/writer/firehose_writer.go
+++ b/writer/firehose_writer.go
@@ -26,6 +26,7 @@ type FirehoseWriter struct {
 	deployEnv              string
 	stringifyNested        bool
 	renameESReservedFields bool
+	minimumTimestamp       time.Time
 
 	// KCL checkpointing
 	sleepDuration        time.Duration
@@ -70,6 +71,8 @@ type FirehoseWriterConfig struct {
 	StringifyNested bool
 	// RenameESReservedFields will rename any field reserved by ES, e.g. _source, to kv__<field>, e.g. kv__source.
 	RenameESReservedFields bool
+	// MinimumTimestamp will reject any logs with a timestamp < MinimumTimestamp
+	MinimumTimestamp time.Time
 }
 
 // NewFirehoseWriter creates a FirehoseWriter
@@ -92,6 +95,7 @@ func NewFirehoseWriter(config FirehoseWriterConfig, limiter *rate.Limiter) (*Fir
 		deployEnv:              config.DeployEnvironment,
 		stringifyNested:        config.StringifyNested,
 		renameESReservedFields: config.RenameESReservedFields,
+		minimumTimestamp:       config.MinimumTimestamp,
 	}
 
 	f.messageBatcher = batcher.New(f, config.FlushInterval, config.FlushCount, config.FlushSize)
@@ -166,7 +170,7 @@ func (f *FirehoseWriter) processRecord(record kcl.Record) error {
 		return err
 	}
 
-	fields, err := decode.ParseAndEnhance(string(data), f.deployEnv, f.stringifyNested, f.renameESReservedFields)
+	fields, err := decode.ParseAndEnhance(string(data), f.deployEnv, f.stringifyNested, f.renameESReservedFields, f.minimumTimestamp)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2236

`ParseAndEnhance` now rejects logs with timestamp < `MinimumTimestamp`.

This will let us do a graceful migration from our existing logging pipeline.
