### PR TITLE
Changes to make analytics consumer easier to implement

### DIFF
--- a/batcher/message_batcher.go
+++ b/batcher/message_batcher.go
@@ -3,6 +3,7 @@ package batcher
 import (
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 )
 
@@ -19,9 +20,20 @@ type Batcher interface {
 	AddMessage(msg []byte, sequenceNumber string, subSequenceNumber int) error
 	// Flush all messages from the batch
 	Flush()
+	// SmallestSeqPair returns the smallest SequenceNumber and SubSequence number in
+	// the current batch
+	SmallestSequencePair() (*big.Int, int)
+}
+
+type msgPack struct {
+	msg       []byte
+	seqNumBig *big.Int
+	subSeqNum int
 }
 
 type batcher struct {
+	mux sync.Mutex
+
 	flushInterval time.Duration
 	flushCount    int
 	flushSize     int
@@ -31,8 +43,13 @@ type batcher struct {
 	largestSeq    *big.Int
 	largestSubSeq int
 
+	// smallestSeq and smallestSubSeq are used to track the highest sequence number
+	// of any record in the batch. This is used for checkpointing.
+	smallestSeq    *big.Int
+	smallestSubSeq int
+
 	sync      Sync
-	msgChan   chan<- []byte
+	msgChan   chan<- msgPack
 	flushChan chan<- struct{}
 }
 
@@ -42,7 +59,7 @@ type batcher struct {
 // - flushCount - number of messages that trigger a flush (default 10).
 // - flushSize - size of batch that triggers a flush (default 1024 * 1024 = 1 mb)
 func New(sync Sync, flushInterval time.Duration, flushCount int, flushSize int) Batcher {
-	msgChan := make(chan []byte, 100)
+	msgChan := make(chan msgPack, 100)
 	flushChan := make(chan struct{})
 
 	b := &batcher{
@@ -57,6 +74,20 @@ func New(sync Sync, flushInterval time.Duration, flushCount int, flushSize int) 
 	go b.startBatcher(msgChan, flushChan)
 
 	return b
+}
+
+func (b *batcher) SmallestSequencePair() (*big.Int, int) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	return b.smallestSeq, b.smallestSubSeq
+}
+
+func (b *batcher) LargestSequencePair() (*big.Int, int) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	return b.largestSeq, b.largestSubSeq
 }
 
 func (b *batcher) SetFlushInterval(dur time.Duration) {
@@ -76,30 +107,37 @@ func (b *batcher) AddMessage(msg []byte, sequenceNumber string, subSequenceNumbe
 		return fmt.Errorf("Empty messages can't be sent")
 	}
 
-	err := b.updateSequenceNumber(sequenceNumber, subSequenceNumber)
-	if err != nil {
-		return err
-	}
-
-	b.msgChan <- msg
-	return nil
-}
-
-// updateSequenceNumber is used to track the highest sequenceNumber of any record in the batch.
-// When flush() is called, the batcher sends the sequence number to the writer. When the writer
-// checkpoints, it does so up to the latest message that was flushed successfully.
-func (b *batcher) updateSequenceNumber(sequenceNumber string, subSequenceNumber int) error {
 	seqNumBig := new(big.Int)
-	if _, ok := seqNumBig.SetString(sequenceNumber, 10); !ok {
+	if _, ok := seqNumBig.SetString(sequenceNumber, 10); !ok { // Validating sequenceNumber
 		return fmt.Errorf("could not parse sequence number '%s'", sequenceNumber)
 	}
 
-	// Check if new seqNumBig is larger
-	if b.largestSeq == nil || seqNumBig.Cmp(b.largestSeq) == 1 || (seqNumBig.Cmp(b.largestSeq) == 0 && subSequenceNumber > b.largestSubSeq) {
-		b.largestSeq = seqNumBig
-		b.largestSubSeq = subSequenceNumber
-	}
+	b.msgChan <- msgPack{msg, seqNumBig, subSequenceNumber}
 	return nil
+}
+
+// updateSequenceNumbers is used to track the highest sequenceNumber of any record in the batch.
+// When flush() is called, the batcher sends the sequence number to the writer. When the writer
+// checkpoints, it does so up to the latest message that was flushed successfully.
+func (b *batcher) updateSequenceNumbers(seqNumBig *big.Int, subSeqNum int) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	isLarger := b.largestSeq == nil ||
+		seqNumBig.Cmp(b.largestSeq) == 1 ||
+		(seqNumBig.Cmp(b.largestSeq) == 0 && subSeqNum > b.largestSubSeq)
+	if isLarger {
+		b.largestSeq = seqNumBig
+		b.largestSubSeq = subSeqNum
+	}
+
+	isSmaller := b.smallestSeq == nil ||
+		seqNumBig.Cmp(b.smallestSeq) == -1 ||
+		(seqNumBig.Cmp(b.smallestSeq) == 0 && subSeqNum < b.smallestSubSeq)
+	if isSmaller {
+		b.smallestSeq = seqNumBig
+		b.smallestSubSeq = subSeqNum
+	}
 }
 
 func (b *batcher) Flush() {
@@ -118,11 +156,12 @@ func (b *batcher) batchSize(batch [][]byte) int {
 func (b *batcher) flush(batch [][]byte) [][]byte {
 	if len(batch) > 0 {
 		b.sync.SendBatch(batch, b.largestSeq, b.largestSubSeq)
+		b.smallestSeq = nil
 	}
 	return [][]byte{}
 }
 
-func (b *batcher) startBatcher(msgChan <-chan []byte, flushChan <-chan struct{}) {
+func (b *batcher) startBatcher(msgChan <-chan msgPack, flushChan <-chan struct{}) {
 	batch := [][]byte{}
 
 	for {
@@ -131,13 +170,14 @@ func (b *batcher) startBatcher(msgChan <-chan []byte, flushChan <-chan struct{})
 			batch = b.flush(batch)
 		case <-flushChan:
 			batch = b.flush(batch)
-		case msg := <-msgChan:
+		case pack := <-msgChan:
 			size := b.batchSize(batch)
-			if b.flushSize < size+len(msg) {
+			if b.flushSize < size+len(pack.msg) {
 				batch = b.flush(batch)
 			}
 
-			batch = append(batch, msg)
+			batch = append(batch, pack.msg)
+			b.updateSequenceNumbers(pack.seqNumBig, pack.subSeqNum)
 
 			if b.flushCount <= len(batch) || b.flushSize <= b.batchSize(batch) {
 				batch = b.flush(batch)

--- a/batcher/message_batcher.go
+++ b/batcher/message_batcher.go
@@ -10,7 +10,7 @@ import (
 // The writer declares how to write messages (via its `SendBatch` method), while the batcher
 // keeps track of messages written
 type Sync interface {
-	SendBatch(batch [][]byte, largestSeq *big.Int, largetsSubSeq int)
+	SendBatch(batch [][]byte, largestSeq *big.Int, largestSubSeq int)
 }
 
 // Batcher interface

--- a/batcher/message_batcher_test.go
+++ b/batcher/message_batcher_test.go
@@ -194,16 +194,21 @@ func TestUpdatingSequence(t *testing.T) {
 
 	t.Log("After AddMessage (seq=1), largestSeq = 1")
 	assert.NoError(batcher.AddMessage([]byte("abab"), "1", mockSubSequenceNumber))
+	sync.waitForFlush(time.Minute)
 	expected.SetInt64(1)
-	assert.True(expected.Cmp(batcher.largestSeq) == 0)
+	seq, _ := batcher.LargestSequencePair()
+	assert.True(expected.Cmp(seq) == 0)
 
 	t.Log("After AddMessage (seq=2), largestSeq = 2")
 	assert.NoError(batcher.AddMessage([]byte("cdcd"), "2", mockSubSequenceNumber))
+	sync.waitForFlush(time.Minute)
 	expected.SetInt64(2)
-	assert.True(expected.Cmp(batcher.largestSeq) == 0)
+	seq, _ = batcher.LargestSequencePair()
+	assert.True(expected.Cmp(seq) == 0)
 
 	t.Log("After AddMessage (seq=1), largestSeq = 2 -- not updated because lower")
 	assert.NoError(batcher.AddMessage([]byte("efef"), "1", mockSubSequenceNumber))
-	assert.True(expected.Cmp(batcher.largestSeq) == 0)
-
+	sync.waitForFlush(time.Minute)
+	seq, _ = batcher.LargestSequencePair()
+	assert.True(expected.Cmp(seq) == 0)
 }

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -528,20 +528,6 @@ func TestExtractKVMeta(t *testing.T) {
 			},
 		},
 		{
-			Description: "_kvmeta with no routes",
-			Team:        "green",
-			Version:     "three",
-			Language:    "tree",
-			Log: map[string]interface{}{
-				"hi": "hello!",
-				"_kvmeta": map[string]interface{}{
-					"team":        "green",
-					"kv_version":  "three",
-					"kv_language": "tree",
-				},
-			},
-		},
-		{
 			Description: "_kvmeta with metric routes",
 			Team:        "green",
 			Version:     "three",

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: d7b0a549c753cc15502fe26998850202eda04364248782ddfa6ac10d8ffe6349
-updated: 2017-05-18T00:53:33.600476459Z
+hash: ef06716cb3faf3a0ddde443d06129ceeb081b4389d60887af0e6c64705355d3b
+updated: 2017-05-23T00:11:59.819968002Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 819b71cf8430e434c1eee7e7e8b0f2b8870be899
+  version: 0b6039ef3d10c1eda49843ebf9773dcc5bba0169
   subpackages:
   - aws
   - aws/awserr
@@ -31,14 +31,9 @@ imports:
   - service/firehose/firehoseiface
   - service/sts
 - name: github.com/Clever/amazon-kinesis-client-go
-  version: 8da04c944f2059941358d76c124dd2dda88902b7
+  version: 92eaacfbf1d207d2753d22313b1c2dcc7593f132
   subpackages:
   - kcl
-- name: github.com/Clever/heka-clever-plugins
-  version: fd3e18929e81329237f543bdc2b63f214b618305
-  subpackages:
-  - aws
-  - batcher
 - name: github.com/Clever/syslogparser
   version: 93ab95f7ff16c9ef1f2d09bc37c0a0c31bad98ea
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,14 +1,9 @@
 package: github.com/Clever/kinesis-to-firehose
 import:
-- package: github.com/Clever/heka-clever-plugins
-  subpackages:
-  - aws
-  - batcher
 - package: github.com/aws/aws-sdk-go
 - package: golang.org/x/time
   subpackages:
   - rate
-- package: github.com/jeromer/syslogparser
 - package: github.com/Clever/syslogparser
 - package: golang.org/x/net
   subpackages:


### PR DESCRIPTION
The analytics consumer has unique needs as a consumer.  At any given time it has several batches (one for each stream it's forwarding to) accumulating at once.  This makes checkpointing a bit more complex.  It's also the first consumer to requirer kvmeta parsing.  This PR includes:

- Message batchers keep track of smallest sequence number.  Sequence numbers are use for checkpointing.
- Implemented KVMeta data parsing
- Upgrade amazon-kinesis-client so the Checkpointer can be cached
- Removed unused dependencies in glide.yml