### PR TITLE
Implemented filter for ES Proxy Logs

### DIFF
--- a/launch/kinesis-to-firehose-log-archive.yml
+++ b/launch/kinesis-to-firehose-log-archive.yml
@@ -13,6 +13,7 @@ env:
 - STRINGIFY_NESTED
 - RENAME_ES_RESERVED_FIELDS
 - MINIMUM_TIMESTAMP
+- FILTER_ES_PROXY_LOGS
 resources:
   cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
   soft_mem_limit: 0.9

--- a/launch/kinesis-to-firehose-log-search.yml
+++ b/launch/kinesis-to-firehose-log-search.yml
@@ -13,6 +13,7 @@ env:
 - STRINGIFY_NESTED
 - RENAME_ES_RESERVED_FIELDS
 - MINIMUM_TIMESTAMP
+- FILTER_ES_PROXY_LOGS
 resources:
   cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
   soft_mem_limit: 0.9

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 		StreamName:             getEnv("FIREHOSE_STREAM_NAME"),
 		StringifyNested:        (os.Getenv("STRINGIFY_NESTED") == "true"),
 		RenameESReservedFields: (os.Getenv("RENAME_ES_RESERVED_FIELDS") == "true"),
+		FilterESProxyLogs:      (os.Getenv("FILTER_ES_PROXY_LOGS") == "true"),
 		MinimumTimestamp:       time.Unix(0, minTimestamp),
 	}
 

--- a/sender/firehose_sender_test.go
+++ b/sender/firehose_sender_test.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"testing"
 
+	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
 	"github.com/Clever/kinesis-to-firehose/sender/mock_firehoseiface"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -25,8 +26,34 @@ func TestInitFirehoseWriter(t *testing.T) {
 func TestProcessRecord(t *testing.T) {
 	sender := setupFirehoseSender(t)
 
-	d := `Apr  5 21:45:54 influx-service docker/0000aa112233[1234]: [httpd] 2017/04/05 21:45:54 172.17.42.1 - heka [05/Apr/2017:21:45:54 +0000] POST /write?db=foo&precision=ms HTTP/1.1 204 0 - Go 1.1 package http 123456-1234-1234-b11b-000000000000 13.688672ms`
-	_, tags, err := sender.ProcessMessage([]byte(d))
+	msg := `Apr  5 21:45:54 influx-service docker/0000aa112233[1234]: [httpd] 2017/04/05 ` +
+		`21:45:54 172.17.42.1 - heka [05/Apr/2017:21:45:54 +0000] POST ` +
+		`/write?db=foo&precision=ms HTTP/1.1 204 0 - Go 1.1 package http ` +
+		`123456-1234-1234-b11b-000000000000 13.688672ms`
+	_, tags, err := sender.ProcessMessage([]byte(msg))
 	assert.NoError(t, err)
 	assert.Contains(t, tags, sender.streamName)
+
+	sender.filterESProxyLogs = true
+	msg = `2017-08-16T04:37:52.901092+00:00 ip-10-0-102-159 production--haproxy-logs/` +
+		`arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F124cc8a5-0549-4149-922b-cd411b813d11` +
+		`[3252]:  {"timestamp":1502858272,"http_status":200,"request_method":"POST","request":"/` +
+		`.kibana-4/__kibanaQueryValidator/_validate/query?explain=true&ignore_unavailable=true",` +
+		`"response_time":25,"termination_state":"----","request_body":"{"query":{"query_string":` +
+		`{"query":"\"Franklin County School District\"","analyze_wildcard":true,` +
+		`"lowercase_expanded_terms":false}}}","backend_name":"elasticsearch"}`
+	_, _, err = sender.ProcessMessage([]byte(msg))
+	assert.Error(t, err)
+	assert.Equal(t, kbc.ErrMessageIgnored, err)
+
+	sender.filterESProxyLogs = false
+	msg = `2017-08-16T04:37:52.901092+00:00 ip-10-0-102-159 production--haproxy-logs/` +
+		`arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F124cc8a5-0549-4149-922b-cd411b813d11` +
+		`[3252]:  {"timestamp":1502858272,"http_status":200,"request_method":"POST","request":"/` +
+		`.kibana-4/__kibanaQueryValidator/_validate/query?explain=true&ignore_unavailable=true",` +
+		`"response_time":25,"termination_state":"----","request_body":"{"query":{"query_string":` +
+		`{"query":"\"Franklin County School District\"","analyze_wildcard":true,` +
+		`"lowercase_expanded_terms":false}}}","backend_name":"elasticsearch"}`
+	_, _, err = sender.ProcessMessage([]byte(msg))
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Because AWS gives ES clusters crazy URLs that can change (eg: if we create a new prod cluster) on a domain we can't control and because the ES server is https only and accepts requests from only a handful of IP's (despite being accessible on the wider internet), we created an app called haproxy-logs.  It gives us a familiar, secure url to kibana that won't change.

The unfortunate consequence of using a clever app to proxy requests to kibanan is that any logs created by haproxy-logs (including request-finished logs) are sent to ES as well.  This pollutes search requests.  For example, the first time you search for "this sting doesn't exists", nothing shows up.  The second time you search for "this sting doesn't exists", a log from haproxy-logs will appear.

Historically we've dealt with this problem by sending logs from haproxy-logs to separate index, but we rarely looked at that index and the logs in that index turned out to be very difficult to interpret, so for simplicity we're going to throw away non-kayvee haproxy-logs for now.

Jira: https://clever.atlassian.net/browse/INFRA-2450
Related: https://github.com/Clever/ark-config/pull/555