### PR TITLE
Updated to work new veresion of kcl-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 2046750b971b081d75389d721052bf790ff5e1cbf4e801ba9e941618c8a223dd
-updated: 2017-09-21T19:03:52.684724251Z
+updated: 2017-09-26T22:05:14.22484999Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 599f09b4d88b78336612acd62e94e6ae87334b4b
+  version: c29655f010eb79efd3df33ea20bbebb4fc80af95
   subpackages:
   - aws
   - aws/awserr
@@ -32,7 +32,7 @@ imports:
   - service/firehose/firehoseiface
   - service/sts
 - name: github.com/Clever/amazon-kinesis-client-go
-  version: 8d871591deb621daf514609758be5fff7cda90c7
+  version: 94aacdf8339bd2cc8400d3bcb323dc1bce2c8422
   subpackages:
   - batchconsumer
   - batchconsumer/stats

--- a/launch/kinesis-to-firehose-log-archive.yml
+++ b/launch/kinesis-to-firehose-log-archive.yml
@@ -10,10 +10,7 @@ env:
 - LOG_FILE
 - READ_RATE_LIMIT
 - DEPLOY_ENV
-- STRINGIFY_NESTED
-- RENAME_ES_RESERVED_FIELDS
-- MINIMUM_TIMESTAMP
-- FILTER_ES_PROXY_LOGS
+- IS_ELASTICSEARCH_CONSUMER
 resources:
   cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
   soft_mem_limit: 0.9

--- a/launch/kinesis-to-firehose-log-search.yml
+++ b/launch/kinesis-to-firehose-log-search.yml
@@ -10,10 +10,7 @@ env:
 - LOG_FILE
 - READ_RATE_LIMIT
 - DEPLOY_ENV
-- STRINGIFY_NESTED
-- RENAME_ES_RESERVED_FIELDS
-- MINIMUM_TIMESTAMP
-- FILTER_ES_PROXY_LOGS
+- IS_ELASTICSEARCH_CONSUMER
 resources:
   cpu: 0.0  # no CPU to improve resource usage (https://clever.atlassian.net/browse/INFRA-2120)
   soft_mem_limit: 0.9

--- a/main.go
+++ b/main.go
@@ -40,15 +40,11 @@ func main() {
 		ReadRateLimit: getEnvInt("READ_RATE_LIMIT"),
 	}
 
-	minTimestamp := int64(getEnvInt("MINIMUM_TIMESTAMP") * int(time.Millisecond))
 	firehoseConfig := sender.FirehoseSenderConfig{
-		DeployEnv:              getEnv("_DEPLOY_ENV"),
-		FirehoseRegion:         getEnv("FIREHOSE_AWS_REGION"),
-		StreamName:             getEnv("FIREHOSE_STREAM_NAME"),
-		StringifyNested:        (os.Getenv("STRINGIFY_NESTED") == "true"),
-		RenameESReservedFields: (os.Getenv("RENAME_ES_RESERVED_FIELDS") == "true"),
-		FilterESProxyLogs:      (os.Getenv("FILTER_ES_PROXY_LOGS") == "true"),
-		MinimumTimestamp:       time.Unix(0, minTimestamp),
+		DeployEnv:       getEnv("_DEPLOY_ENV"),
+		FirehoseRegion:  getEnv("FIREHOSE_AWS_REGION"),
+		StreamName:      getEnv("FIREHOSE_STREAM_NAME"),
+		IsElasticsearch: (os.Getenv("IS_ELASTICSEARCH_CONSUMER") == "true"),
 	}
 
 	sender := sender.NewFirehoseSender(firehoseConfig)

--- a/sender/firehose_sender_test.go
+++ b/sender/firehose_sender_test.go
@@ -3,10 +3,11 @@ package sender
 import (
 	"testing"
 
-	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
-	"github.com/Clever/kinesis-to-firehose/sender/mock_firehoseiface"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
+	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
+	"github.com/Clever/kinesis-to-firehose/sender/mock_firehoseiface"
 )
 
 func setupFirehoseSender(t *testing.T) *FirehoseSender {
@@ -23,7 +24,7 @@ func TestInitFirehoseWriter(t *testing.T) {
 	_ = setupFirehoseSender(t)
 }
 
-func TestProcessRecord(t *testing.T) {
+func TestProcessMessageForES(t *testing.T) {
 	sender := setupFirehoseSender(t)
 
 	msg := `Apr  5 21:45:54 influx-service docker/0000aa112233[1234]: [httpd] 2017/04/05 ` +
@@ -56,4 +57,80 @@ func TestProcessRecord(t *testing.T) {
 		`"lowercase_expanded_terms":false}}}","backend_name":"elasticsearch"}`
 	_, _, err = sender.ProcessMessage([]byte(msg))
 	assert.NoError(t, err)
+}
+
+func TestMakeESSafe(t *testing.T) {
+	sender := setupFirehoseSender(t)
+
+	fields := map[string]interface{}{
+		"_no_prefix_underscore": "yes",
+		"no.dots.in.props":      "yes",
+		"no-nesting":            map[string]interface{}{"nested": "nest"},
+		"no-arrays":             []interface{}{"no", "array"},
+	}
+	expected := map[string]interface{}{
+		"kv__no_prefix_underscore": "yes",
+		"no_dots_in_props":         "yes",
+		"no-nesting":               `{"nested":"nest"}`,
+		"no-arrays":                `["no","array"]`,
+	}
+
+	assert.EqualValues(t, expected, sender.makeESSafe(fields))
+}
+
+func TestAddKVMetaFields(t *testing.T) {
+	assert := assert.New(t)
+
+	sender := setupFirehoseSender(t)
+	fields := map[string]interface{}{
+		"hi": "hello!",
+		"_kvmeta": map[string]interface{}{
+			"team":        "diversity",
+			"kv_version":  "kv-routes",
+			"kv_language": "understanding",
+			"routes": []interface{}{
+				map[string]interface{}{
+					"type":       "metrics",
+					"rule":       "all-combos",
+					"series":     "1,1,2,6,24,120,720,5040",
+					"dimensions": []interface{}{"fact", "orial"},
+				},
+				map[string]interface{}{
+					"type":   "analytics",
+					"rule":   "there's-app-invites-everywhere",
+					"series": "there's-bts-in-the-air",
+				},
+				map[string]interface{}{
+					"type":    "notifications",
+					"rule":    "what's-the-catch",
+					"channel": "slack-is-built-with-php",
+					"message": "just like farmville",
+				},
+				map[string]interface{}{
+					"type":        "alerts",
+					"rule":        "last-call",
+					"series":      "doing-it-til-we-fall",
+					"dimensions":  []interface{}{"who", "where"},
+					"stat_type":   "guage",
+					"value_field": "status",
+				},
+			},
+		},
+	}
+	fields = sender.addKVMetaFields(fields)
+
+	assert.NotContains(fields, "_kvmeta")
+	assert.Contains(fields, "kv_routes")
+	assert.Contains(fields, "kv_team")
+	assert.Contains(fields, "kv_language")
+	assert.Contains(fields, "kv_version")
+
+	assert.Equal(
+		[]string{"all-combos", "there's-app-invites-everywhere", "what's-the-catch", "last-call"},
+		fields["kv_routes"],
+	)
+	assert.Equal("diversity", fields["kv_team"])
+	assert.Equal("understanding", fields["kv_language"])
+	assert.Equal("kv-routes", fields["kv_version"])
+
 }

--- a/sender/firehose_sender_test.go
+++ b/sender/firehose_sender_test.go
@@ -34,7 +34,7 @@ func TestProcessRecord(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, tags, sender.streamName)
 
-	sender.filterESProxyLogs = true
+	sender.isElasticsearch = true
 	msg = `2017-08-16T04:37:52.901092+00:00 ip-10-0-102-159 production--haproxy-logs/` +
 		`arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F124cc8a5-0549-4149-922b-cd411b813d11` +
 		`[3252]:  {"timestamp":1502858272,"http_status":200,"request_method":"POST","request":"/` +
@@ -46,7 +46,7 @@ func TestProcessRecord(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, kbc.ErrMessageIgnored, err)
 
-	sender.filterESProxyLogs = false
+	sender.isElasticsearch = false
 	msg = `2017-08-16T04:37:52.901092+00:00 ip-10-0-102-159 production--haproxy-logs/` +
 		`arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F124cc8a5-0549-4149-922b-cd411b813d11` +
 		`[3252]:  {"timestamp":1502858272,"http_status":200,"request_method":"POST","request":"/` +


### PR DESCRIPTION
- Moved a lot of ES specific parsing logic to this consumer
- Added kv_routes, kv_team, kv_lang, kv_version to make app log-routing easier to debug
- Added code that replaces `.`'s in property names with `_`.  ES v2.3 rejects them
- Added code that replaces underscores at the beginning of field names with `kv_`.  ES v2.3 rejects them

Related: https://github.com/Clever/ark-config/pull/616
Pending: https://github.com/Clever/amazon-kinesis-client-go/pull/19