### PR TITLE
Avoid index out of range panic

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 2046750b971b081d75389d721052bf790ff5e1cbf4e801ba9e941618c8a223dd
-updated: 2017-09-26T22:05:14.22484999Z
+updated: 2017-11-05T15:02:39.992184216Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: c29655f010eb79efd3df33ea20bbebb4fc80af95
+  version: d46843b92a3a8e377d7fe24b4d70fca37f923d00
   subpackages:
   - aws
   - aws/awserr
@@ -68,7 +68,7 @@ imports:
   subpackages:
   - rate
 - name: gopkg.in/Clever/kayvee-go.v6
-  version: e6f953eac5b9d8e41dff6587e0ae6d58b50da5c5
+  version: e1e6fd8184162847c1123645e7058347a2fd3959
   subpackages:
   - logger
   - router

--- a/golang.mk
+++ b/golang.mk
@@ -1,6 +1,7 @@
 # This is the default Clever Golang Makefile.
+# It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.1.3
+GOLANG_MK_VERSION := 0.1.5
 
 SHELL := /bin/bash
 .PHONY: golang-godep-vendor golang-test-deps $(GODEP)
@@ -9,13 +10,21 @@ SHELL := /bin/bash
 GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
 
 # This block checks and confirms that the proper Go toolchain version is installed.
+# It uses ^ matching in the semver sense -- you can be ahead by a minor
+# version, but not a major version (patch is ignored).
 # arg1: golang version
 define golang-version-check
-GOVERSION := $(shell go version | grep $(1))
-_ := $(if \
-	$(shell go version | grep $(1)), \
-	@echo "", \
-	$(error "must be running Go version $(1)"))
+_ := $(if  \
+		$(shell  \
+			expr >/dev/null  \
+				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f2`  \
+				\>= `echo $(1) | cut -d. -f2`  \
+				\&  \
+				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f1`  \
+				= `echo $(1) | cut -d. -f1`  \
+			&& echo 1),  \
+		@echo "",  \
+		$(error must be running Go version ^$(1) - you are running $(shell go version | cut -d" " -f3 | cut -c3-)))
 endef
 
 export GO15VENDOREXPERIMENT=1

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -55,7 +55,7 @@ func NewFirehoseSender(config FirehoseSenderConfig) *FirehoseSender {
 
 func (f *FirehoseSender) makeKeyESSafe(key string) string {
 	// ES doesn't like fields that start with underscores.
-	if []rune(key)[0] == '_' {
+	if len(key) > 0 && []rune(key)[0] == '_' {
 		key = "kv_" + key
 	}
 

--- a/sender/firehose_sender_test.go
+++ b/sender/firehose_sender_test.go
@@ -67,12 +67,14 @@ func TestMakeESSafe(t *testing.T) {
 		"no.dots.in.props":      "yes",
 		"no-nesting":            map[string]interface{}{"nested": "nest"},
 		"no-arrays":             []interface{}{"no", "array"},
+		"":                      "empty",
 	}
 	expected := map[string]interface{}{
 		"kv__no_prefix_underscore": "yes",
 		"no_dots_in_props":         "yes",
 		"no-nesting":               `{"nested":"nest"}`,
 		"no-arrays":                `["no","array"]`,
+		"":                         "empty",
 	}
 
 	assert.EqualValues(t, expected, sender.makeESSafe(fields))


### PR DESCRIPTION
starting 2am yesterday morning k-to-f-log-search containers started restarting a ton

![image](https://user-images.githubusercontent.com/72655/32416107-71d5e4e4-c1f8-11e7-9af7-2cf162516dcf.png)

One of the crash logs points to the LOC changed in this PR: https://production--haproxy-logs.int.clever.com/_plugin/kibana/#/discover?_g=(refreshInterval:(display:Off,pause:!f,section:0,value:0),time:(from:'2017-11-04T08:59:00.000Z',mode:absolute,to:'2017-11-04T09:00:00.000Z'))&_a=(columns:!(rawlog),filters:!((meta:(disabled:!f,index:%5Blogs-%5DYYYY-MM-DD,key:container_task,negate:!f,value:e4d0eb9a-1d8f-4946-af2e-ab4b431e342a),query:(match:(container_task:(query:e4d0eb9a-1d8f-4946-af2e-ab4b431e342a,type:phrase))))),index:%5Blogs-%5DYYYY-MM-DD,interval:auto,query:(query_string:(analyze_wildcard:!t,lowercase_expanded_terms:!f,query:'container_app:kinesis-to-firehose-log-search%20AND%20%22SEVERE:%20Received%20error%20line%20from%20subprocess%22')),sort:!(timestamp,desc))
