### PR TITLE
Ignores SEVERE errors from kinesis-cloudtrail-consumer

### DIFF
--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -119,6 +119,12 @@ func (f *FirehoseSender) ProcessMessage(rawlog []byte) ([]byte, []string, error)
 			return nil, nil, kbc.ErrMessageIgnored
 		}
 
+		// Ignore log lines from the kinesis-cloudtrail-consumer starting with SEVERE, since they
+		// are an unintended result of logging while using KCL
+		if fields["container_app"] == "kinesis-cloudtrail-consumer" && strings.HasPrefix(fields["rawlog"].(string), "SEVERE") {
+			return nil, nil, kbc.ErrMessageIgnored
+		}
+
 		fields = f.addKVMetaFields(fields)
 		fields = f.makeESSafe(fields)
 	}

--- a/sender/firehose_sender_test.go
+++ b/sender/firehose_sender_test.go
@@ -47,6 +47,17 @@ func TestProcessMessageForES(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, kbc.ErrMessageIgnored, err)
 
+	sender.isElasticsearch = true
+	msg = `2017-08-16T04:37:52.901092+00:00 ip-10-0-102-159 production--kinesis-cloudtrail-consumer/` +
+		`arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F124cc8a5-0549-4149-922b-cd411b813d11` +
+		`[3252]: SEVERE: Received error line from subprocess [{"awsRegion":"us-east-1","deploy_env"` +
+		`:"production","eventID":"93f997cc-e14e-4ca1-a5d1-9341c97da442","eventName":"GetBucketLocation"` +
+		`,"eventSource":"s3.amazonaws.com","eventTime":"2017-12-06T19:18:22Z","eventType":"AwsApiCall"}]` +
+		`for shard shardId-000000000000`
+	_, _, err = sender.ProcessMessage([]byte(msg))
+	assert.Error(t, err)
+	assert.Equal(t, kbc.ErrMessageIgnored, err)
+
 	sender.isElasticsearch = false
 	msg = `2017-08-16T04:37:52.901092+00:00 ip-10-0-102-159 production--haproxy-logs/` +
 		`arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2F124cc8a5-0549-4149-922b-cd411b813d11` +


### PR DESCRIPTION
This should prevent us from adding these types of logs to elasticsearch: https://production--haproxy-logs.int.clever.com/_plugin/kibana/#/doc/%5Blogs-%5DYYYY-MM-DD/logs-2017-12-07/daily-logs?id=49576373123608160677314437947449964835214226517034795218.0&_g=(refreshInterval:(display:Off,pause:!f,section:0,value:0),time:(from:now-7d,mode:quick,to:now))