### PR TITLE
Drop logs when behind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -y update && apt-get install -y -q build-essential
 ADD jars jars
 ADD consumer.properties.template .
 ADD run_kcl.sh .
+ADD kvconfig.yml .
 ADD kinesis-consumer kinesis-consumer
 
 ENTRYPOINT ["/bin/bash", "./run_kcl.sh"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,14 +4,8 @@
 [[projects]]
   branch = "master"
   name = "github.com/Clever/amazon-kinesis-client-go"
-  packages = [
-    "batchconsumer",
-    "batchconsumer/stats",
-    "decode",
-    "kcl",
-    "splitter"
-  ]
-  revision = "3ded2fcd2deeaf3136090982f18f8de0a99f3c3e"
+  packages = ["batchconsumer","batchconsumer/stats","decode","kcl","splitter"]
+  revision = "6e45fa518bec79c63ede149760180e22572e2faf"
 
 [[projects]]
   branch = "master"
@@ -21,59 +15,27 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/sdkrand",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/json/jsonutil",
-    "private/protocol/jsonrpc",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/xml/xmlutil",
-    "service/firehose",
-    "service/firehose/firehoseiface",
-    "service/sts"
-  ]
-  revision = "f9a6880d84e16e2a37055793e17164a228d637f4"
-  version = "v1.13.1"
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/sdkio","internal/sdkrand","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/firehose","service/firehose/firehoseiface","service/sts"]
+  revision = "31a85efbe3bc741eb539d6310c8e66030b7c5cb7"
+  version = "v1.13.47"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "e7fea39b01aea8d5671f6858f0532f56e8bff3a5"
-  version = "v1.27.0"
+  revision = "6529cf7c58879c08d927016dde4477f18a0634cb"
+  version = "v1.36.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/mock"
-  packages = [
-    "gomock",
-    "mockgen",
-    "mockgen/model"
-  ]
-  revision = "58cd061d09382b6011f84c1291ebe50ef2e25bab"
+  packages = ["gomock","mockgen","mockgen/model"]
+  revision = "22bbf0ddf08105dfa364d0a2fa619dfa71014af5"
 
 [[projects]]
   branch = "master"
@@ -89,59 +51,60 @@
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
-  revision = "6fe8760cad3569743d51ddbb243b26f8456742dc"
+  revision = "4e3ac2762d5f479393488629ee9370b50873b3a6"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonreference"
   packages = ["."]
-  revision = "e02fc20de94c78484cd5ffb007f8af96be030a45"
+  revision = "bd5ef7bd5415a7ac448318e64f11a24cd21e594b"
 
 [[projects]]
+  branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "702b404897d4364af44dc8dcabc9815947942325"
+  revision = "2c8e4be869c17540b336bab0ea18b8d73e6a28b7"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["context"]
-  revision = "5602c733f70afc6dcec6766be0d5034d4c4f14de"
+  revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/time"
   packages = ["rate"]
-  revision = "f51c12702a4d776e4c1fa9b0fabab841babae631"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  packages = [
-    ".",
-    "logger",
-    "router"
-  ]
-  revision = "e1e6fd8184162847c1123645e7058347a2fd3959"
-  version = "v6.10.0"
+  packages = [".","logger","router"]
+  revision = "77f05943b48b0cb82c705ec9e40bed66e7cf79c1"
+  version = "v6.12.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d8e2981ed88fc07587eb02fcba362df7b6d36aa9f8d4181c7c9a6454b9ef444d"
+  inputs-digest = "85c981b39abbea16c29030439485913b965e0c86e3b90618ccc2294d544f994a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -142,6 +142,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "85c981b39abbea16c29030439485913b965e0c86e3b90618ccc2294d544f994a"
+  inputs-digest = "d8e2981ed88fc07587eb02fcba362df7b6d36aa9f8d4181c7c9a6454b9ef444d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -1,0 +1,10 @@
+routes:
+  dropped-logs-alert:
+    matchers:
+      title: ["drop-stats"]
+    output:
+      type: "alerts"
+      series: "kinesis-to-firehose-log-search.drop-stats"
+      dimensions: []
+      stat_type: "gauge"
+      value_field: "total_dropped"

--- a/main.go
+++ b/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"log"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
 	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
 
 	"github.com/Clever/kinesis-to-firehose/sender"
 )
@@ -31,6 +33,16 @@ func getEnvInt(envVar string) int {
 }
 
 func main() {
+	exePath, err := os.Executable()
+	if err != nil {
+		log.Fatal(err)
+	}
+	dir := path.Dir(exePath)
+	err = logger.SetGlobalRouting(path.Join(dir, "kvconfig.yml"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	suffix := "." + time.Now().Format("2006-01-02T15:04:05") + ".log"
 	kbcConfig := kbc.Config{
 		BatchInterval:  10 * time.Second,

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -116,9 +116,11 @@ func (f *FirehoseSender) calcDropLogProbability(fields map[string]interface{}) f
 	}
 
 	level := ""
-	if _, ok := fields["level"]; ok {
-		level = fields["level"].(string)
+	switch l := fields["level"].(type) {
+	case string:
+		level = l
 	}
+
 	if level == "" {
 		level = "debug" // Treat unknown levels like "debug"
 

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -13,6 +13,7 @@ import (
 
 	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
 	"github.com/Clever/amazon-kinesis-client-go/decode"
+	"github.com/Clever/kinesis-to-firehose/sender/stats"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
 
@@ -166,6 +167,7 @@ func (f *FirehoseSender) ProcessMessage(rawlog []byte) ([]byte, []string, error)
 		}
 
 		if rand.Float64() < f.calcDropLogProbability(fields) {
+			stats.LogDropped(fields) // Here for alerting
 			return nil, nil, kbc.ErrMessageIgnored
 		}
 

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -107,22 +107,22 @@ func (f *FirehoseSender) addKVMetaFields(fields map[string]interface{}) map[stri
 	return fields
 }
 
-func (f *FirehoseSender) calcDropLogProbability(log map[string]interface{}) float64 {
-	logTime := log["timestamp"].(time.Time)
+func (f *FirehoseSender) calcDropLogProbability(fields map[string]interface{}) float64 {
+	logTime := fields["timestamp"].(time.Time)
 	delay := time.Since(logTime).Seconds() - 120
 	if delay <= 0 { // Don't drop logs with less than 2 minute delay
 		return 0
 	}
 
 	level := ""
-	if _, ok := log["level"]; ok {
-		level = log["level"].(string)
+	if _, ok := fields["level"]; ok {
+		level = fields["level"].(string)
 	}
 	if level == "" {
 		level = "debug" // Treat unknown levels like "debug"
 
 		// Don't throw away panics and error messages
-		raw := strings.ToLower(log["rawlog"].(string))
+		raw := strings.ToLower(fields["rawlog"].(string))
 		if strings.Contains(raw, "panic") || strings.Contains(raw, "err") {
 			level = "critical"
 		}

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -114,7 +114,10 @@ func (f *FirehoseSender) calcDropLogProbability(log map[string]interface{}) floa
 		return 0
 	}
 
-	level := log["level"].(string)
+	level := ""
+	if _, ok := log["level"]; ok {
+		level = log["level"].(string)
+	}
 	if level == "" {
 		level = "debug" // Treat unknown levels like "debug"
 

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -2,6 +2,7 @@ package sender
 
 import (
 	"encoding/json"
+	"math"
 	"math/rand"
 	"strings"
 	"time"
@@ -146,7 +147,7 @@ func (f *FirehoseSender) calcDropLogProbability(fields map[string]interface{}) f
 		half_dropped = 14400 // 240 minutes
 	}
 
-	return delay / (half_dropped + delay)
+	return 1 - math.Exp2(-delay/half_dropped)
 }
 
 // ProcessMessage processes messages

--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -130,7 +130,7 @@ func (f *FirehoseSender) calcDropLogProbability(fields map[string]interface{}) f
 
 	var half_dropped float64 // the delay in which half the logs will be dropped
 	switch level {
-	case "error", "critical":
+	case "critical":
 		return 0 // Never drop error or critical levels
 	case "trace":
 		half_dropped = 600 // 10 minutes
@@ -142,6 +142,8 @@ func (f *FirehoseSender) calcDropLogProbability(fields map[string]interface{}) f
 		half_dropped = 3600 // 60 minutes
 	case "warning":
 		half_dropped = 7200 // 120 minutes
+	case "error":
+		half_dropped = 14400 // 240 minutes
 	}
 
 	return delay / (half_dropped + delay)

--- a/sender/stats/stats.go
+++ b/sender/stats/stats.go
@@ -31,7 +31,7 @@ func init() {
 				for k, v := range dropped {
 					tmp[k] = v
 				}
-				log.InfoD("drop-stats", tmp)
+				log.TraceD("drop-stats", tmp)
 
 				dropped = map[string]int{}
 				total = 0

--- a/sender/stats/stats.go
+++ b/sender/stats/stats.go
@@ -1,0 +1,54 @@
+package stats
+
+import (
+	"time"
+
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+)
+
+var log = logger.New("kinesis-to-firehose-log-search")
+
+type datum struct {
+	app   string
+	level string
+}
+
+var queue = make(chan datum, 2)
+
+func init() {
+	dropped := map[string]int{}
+	total := 0
+	tick := time.Tick(time.Minute)
+	go func() {
+		for {
+			select {
+			case d := <-queue:
+				dropped["app="+d.app] += 1
+				dropped["level="+d.level] += 1
+				total += 1
+			case <-tick:
+				tmp := logger.M{"total_dropped": total}
+				for k, v := range dropped {
+					tmp[k] = v
+				}
+				log.InfoD("drop-stats", tmp)
+
+				dropped = map[string]int{}
+				total = 0
+			}
+		}
+	}()
+}
+
+func LogDropped(log map[string]interface{}) {
+	app, ok := log["container_app"].(string)
+	if !ok || app == "" {
+		app = "<unknown>"
+	}
+	level, ok := log["level"].(string)
+	if !ok || level == "" {
+		level = "debug"
+	}
+
+	queue <- datum{app, level}
+}


### PR DESCRIPTION
When logs are delayed, the kinesis-to-firehose-log-search consumer will probabilistically drop logs based on their delay and log level.  The more the delayed the log, the more likely it is to be dropped.  Similarly, the lower the log level (ex: debug vs warning), the more likely it is to be dropped.

Log with less than 2 minutes of delay are not dropped.
Log with level "critical" are not dropped either.

This code also includes a go routine that logs stats about dropped logs every minute.

For more info:
Spec: https://docs.google.com/document/d/1LXJVQwRDL7nnHxpc25BquaPUwNz03ryyofgjTlSiUWA/edit#
Jira: https://clever.atlassian.net/browse/INFRA-2961