### PR TITLE
drop logs after 1 minute of log delay

### DIFF
--- a/sender/firehose_sender.go
+++ b/sender/firehose_sender.go
@@ -110,8 +110,8 @@ func (f *FirehoseSender) addKVMetaFields(fields map[string]interface{}) map[stri
 
 func (f *FirehoseSender) calcDropLogProbability(fields map[string]interface{}) float64 {
 	logTime := fields["timestamp"].(time.Time)
-	delay := time.Since(logTime).Seconds() - 120
-	if delay <= 0 { // Don't drop logs with less than 2 minute delay
+	delay := time.Since(logTime).Seconds() - 60
+	if delay <= 0 { // Don't drop logs with less than 1 minute delay
 		return 0
 	}
 

--- a/sender/stats/stats.go
+++ b/sender/stats/stats.go
@@ -43,7 +43,7 @@ func init() {
 func LogDropped(log map[string]interface{}) {
 	app, ok := log["container_app"].(string)
 	if !ok || app == "" {
-		app = "<unknown>"
+		app = "_UNKNOWN_"
 	}
 	level, ok := log["level"].(string)
 	if !ok || level == "" {


### PR DESCRIPTION
- also use _UNKNOWN_ rather than `<` since that get's converted to a
unicode char